### PR TITLE
A bug in iter_confusion_matrices

### DIFF
--- a/yard/data.py
+++ b/yard/data.py
@@ -381,7 +381,7 @@ class BinaryClassifierData(object):
 
         thresholds.append(float('inf'))
 
-        result = BinaryConfusionMatrix(tp=0,fp=0,tn=0,fn=0)
+        result = BinaryConfusionMatrix(tp=self.total_positives,fp=self.total_negatives,tn=0,fn=0)
 
         row_idx, n = 0, len(self)
         for threshold in thresholds:


### PR DESCRIPTION
This is the bug.

``` python
import yard
a = [(10,1),(20,0),(30,0),(40,1)]
d = yard.BinaryClassifierData(a)
list(d.iter_confusion_matrices([20,30,40]))
[(20, BinaryConfusionMatrix(tp=-1, fp=0, fn=3, tn=2)),
 (30, BinaryConfusionMatrix(tp=0, fp=1, fn=2, tn=1)),
 (40, BinaryConfusionMatrix(tp=0, fp=0, fn=2, tn=2)),
 (inf, BinaryConfusionMatrix(tp=-1, fp=0, fn=3, tn=2))]

Clearly, tp=-1 is wrong.
```
